### PR TITLE
fix: navbar 404 status link

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -23,7 +23,7 @@ status-website:
   # introMessage: This is a sample status page which uses **real-time** data from our [GitHub repository](https://github.com/upptime/upptime). No server required — just GitHub Actions, Issues, and Pages. [**Get your own for free**](https://github.com/upptime/upptime)
   navbar:
     - title: Status
-      href: /hackmd-api-uptime
+      href: /history/hack-md
     - title: GitHub
       href: https://github.com/$OWNER/$REPO
     - title: HackMD


### PR DESCRIPTION
Currently, `/hackmd-api-uptime/` redirects to a 404 page, so I changed it to the main HackMD status history.